### PR TITLE
fix: let fcitx5 discover table dicts

### DIFF
--- a/patches/chinese-addons.patch
+++ b/patches/chinese-addons.patch
@@ -1,12 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5686f38..c09d733 100644
+index 5686f38..936ecd2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -65,6 +65,7 @@ endif()
+@@ -65,6 +65,8 @@ endif()
  find_package(Boost 1.61 REQUIRED COMPONENTS iostreams)
  find_package(LibIMEPinyin 1.1.3 REQUIRED)
  find_package(LibIMETable 1.1.4 REQUIRED)
 +pkg_check_modules(ZSTD REQUIRED IMPORTED_TARGET "libzstd")
++set(LIBIME_INSTALL_PKGDATADIR "../libime")
  
  if (ENABLE_CLOUDPINYIN)
      pkg_check_modules(Curl REQUIRED IMPORTED_TARGET "libcurl")


### PR DESCRIPTION
make sure to `rm -rf /tmp/fcitx5/share/libime` before testing.

- before: table-based input methods are "not available".
- after: they should be usable now.