### PR TITLE
fix rejected key release resets candidate window

### DIFF
--- a/patches/rime.patch
+++ b/patches/rime.patch
@@ -82,7 +82,7 @@ index 3ecc012..6bec003 100644
          this, "UserDataDir", _("User data dir"),
          stringutils::concat(
 diff --git a/src/rimestate.cpp b/src/rimestate.cpp
-index a8fe4b9..5dbc18f 100644
+index a8fe4b9..e180c48 100644
 --- a/src/rimestate.cpp
 +++ b/src/rimestate.cpp
 @@ -11,6 +11,7 @@
@@ -107,7 +107,26 @@ index a8fe4b9..5dbc18f 100644
  
  std::string RimeState::subMode() {
      std::string result;
-@@ -440,6 +446,30 @@ void RimeState::updateUI(InputContext *ic, bool keyRelease) {
+@@ -226,11 +232,13 @@ void RimeState::keyEvent(KeyEvent &event) {
+         engine_->instance()->resetCompose(ic);
+     }
+ 
+-    updateUI(ic, event.isRelease());
+-    if (!event.isRelease() && !lastSchema.empty() &&
+-        lastSchema == currentSchema() && ic->inputPanel().empty() &&
+-        !changedOptions_.empty()) {
+-        showChangedOptions();
++    if (event.accepted()) {
++        updateUI(ic, event.isRelease());
++        if (!event.isRelease() && !lastSchema.empty() &&
++            lastSchema == currentSchema() && ic->inputPanel().empty() &&
++            !changedOptions_.empty()) {
++            showChangedOptions();
++        }
+     }
+ }
+ 
+@@ -440,6 +448,30 @@ void RimeState::updateUI(InputContext *ic, bool keyRelease) {
  
  void RimeState::release() { session_.reset(); }
  


### PR DESCRIPTION
https://github.com/fcitx-contrib/fcitx5-macos/pull/188 only works for single key.

Test:
* Map CapsLock to Hyper (Ctrl+Option+Command+Shift) and then Hyper+HJKL to Left, Down, Up, Right by writing `.config/karabiner/karabiner.json`:
```json
{
    "profiles": [
        {
            "complex_modifications": {
                "rules": [
                    {
                        "description": "Caps Lock → Hyper Key (⌃⌥⇧⌘) (Caps Lock if alone)",
                        "manipulators": [
                            {
                                "from": { "key_code": "caps_lock" },
                                "to": [
                                    {
                                        "key_code": "left_shift",
                                        "modifiers": ["left_command", "left_control", "left_option"]
                                    }
                                ],
                                "to_if_alone": [{ "key_code": "caps_lock" }],
                                "type": "basic"
                            }
                        ]
                    },
                    {
                        "description": "Hyper + h/j/k/l == vim directional Keys",
                        "manipulators": [
                            {
                                "from": {
                                    "key_code": "k",
                                    "modifiers": { "mandatory": ["left_shift", "left_command", "left_control", "left_option"] }
                                },
                                "to": [{ "key_code": "up_arrow" }],
                                "type": "basic"
                            },
                            {
                                "from": {
                                    "key_code": "h",
                                    "modifiers": { "mandatory": ["left_shift", "left_command", "left_control", "left_option"] }
                                },
                                "to": [{ "key_code": "left_arrow" }],
                                "type": "basic"
                            },
                            {
                                "from": {
                                    "key_code": "j",
                                    "modifiers": { "mandatory": ["left_shift", "left_command", "left_control", "left_option"] }
                                },
                                "to": [{ "key_code": "down_arrow" }],
                                "type": "basic"
                            },
                            {
                                "from": {
                                    "key_code": "l",
                                    "modifiers": { "mandatory": ["left_shift", "left_command", "left_control", "left_option"] }
                                },
                                "to": [{ "key_code": "right_arrow" }],
                                "type": "basic"
                            },
                            {
                                "from": {
                                    "key_code": "semicolon",
                                    "modifiers": { "mandatory": ["left_shift", "left_command", "left_control", "left_option"] }
                                },
                                "to": [
                                    {
                                        "key_code": "right_arrow",
                                        "modifiers": ["left_command"]
                                    }
                                ],
                                "type": "basic"
                            }
                        ]
                    }
                ]
            }
        }
    ]
}
```
* Expand scroll for any rime schema, then Hyper+J should move highlight down, and no reset on release.